### PR TITLE
rt: fix wasm target by removing time from metrics

### DIFF
--- a/tokio/src/runtime/metrics/batch.rs
+++ b/tokio/src/runtime/metrics/batch.rs
@@ -12,7 +12,7 @@ pub(crate) struct MetricsBatch {
     busy_duration_total: u64,
 
     /// Instant at which work last resumed (continued after park).
-    processing_scheduled_tasks_started_at: Instant,
+    processing_scheduled_tasks_started_at: Option<Instant>,
 
     /// Number of times the worker parked.
     park_count: u64,
@@ -67,17 +67,17 @@ cfg_unstable_metrics! {
 
 impl MetricsBatch {
     pub(crate) fn new(worker_metrics: &WorkerMetrics) -> MetricsBatch {
-        let now = Instant::now();
-        Self::new_unstable(worker_metrics, now)
+        let maybe_now = now();
+        Self::new_unstable(worker_metrics, maybe_now)
     }
 
     cfg_metrics_variant! {
         stable: {
             #[inline(always)]
-            fn new_unstable(_worker_metrics: &WorkerMetrics, now: Instant) -> MetricsBatch {
+            fn new_unstable(_worker_metrics: &WorkerMetrics, maybe_now: Option<Instant>) -> MetricsBatch {
                 MetricsBatch {
                     busy_duration_total: 0,
-                    processing_scheduled_tasks_started_at: now,
+                    processing_scheduled_tasks_started_at: maybe_now,
                     park_count: 0,
                     park_unpark_count: 0,
                 }
@@ -85,7 +85,16 @@ impl MetricsBatch {
         },
         unstable: {
             #[inline(always)]
-            fn new_unstable(worker_metrics: &WorkerMetrics, now: Instant) -> MetricsBatch {
+            fn new_unstable(worker_metrics: &WorkerMetrics, maybe_now: Option<Instant>) -> MetricsBatch {
+                let poll_timer = maybe_now.and_then(|now| {
+                    worker_metrics
+                        .poll_count_histogram
+                        .as_ref()
+                        .map(|worker_poll_counts| PollTimer {
+                            poll_counts: HistogramBatch::from_histogram(worker_poll_counts),
+                            poll_started_at: now,
+                        })
+                });
                 MetricsBatch {
                     park_count: 0,
                     park_unpark_count: 0,
@@ -97,13 +106,8 @@ impl MetricsBatch {
                     local_schedule_count: 0,
                     overflow_count: 0,
                     busy_duration_total: 0,
-                    processing_scheduled_tasks_started_at: now,
-                    poll_timer: worker_metrics.poll_count_histogram.as_ref().map(
-                        |worker_poll_counts| PollTimer {
-                            poll_counts: HistogramBatch::from_histogram(worker_poll_counts),
-                            poll_started_at: now,
-                        },
-                    ),
+                    processing_scheduled_tasks_started_at: maybe_now,
+                    poll_timer,
                 }
             }
         }
@@ -186,13 +190,17 @@ impl MetricsBatch {
 
     /// Start processing a batch of tasks
     pub(crate) fn start_processing_scheduled_tasks(&mut self) {
-        self.processing_scheduled_tasks_started_at = Instant::now();
+        self.processing_scheduled_tasks_started_at = now();
     }
 
     /// Stop processing a batch of tasks
     pub(crate) fn end_processing_scheduled_tasks(&mut self) {
-        let busy_duration = self.processing_scheduled_tasks_started_at.elapsed();
-        self.busy_duration_total += duration_as_u64(busy_duration);
+        if let Some(processing_scheduled_tasks_started_at) =
+            self.processing_scheduled_tasks_started_at
+        {
+            let busy_duration = processing_scheduled_tasks_started_at.elapsed();
+            self.busy_duration_total += duration_as_u64(busy_duration);
+        }
     }
 
     cfg_metrics_variant! {
@@ -278,4 +286,13 @@ cfg_rt_multi_thread! {
 
 pub(crate) fn duration_as_u64(dur: Duration) -> u64 {
     u64::try_from(dur.as_nanos()).unwrap_or(u64::MAX)
+}
+
+/// `WASM` does not support time: <https://github.com/tokio-rs/tokio/issues/7319>
+fn now() -> Option<Instant> {
+    if cfg!(target_family = "wasm") {
+        None
+    } else {
+        Some(Instant::now())
+    }
 }


### PR DESCRIPTION
time is unsupported in WASM, fix involves removing Instant from metrics handling for cfg gated WASM target family as a stopgap solution

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
